### PR TITLE
fix bottom renderflow exception

### DIFF
--- a/lib/screens/ImageScreen.dart
+++ b/lib/screens/ImageScreen.dart
@@ -35,14 +35,17 @@ class ImageScreenState extends State<ImageScreen> {
           ? Center(
           child: Text('No Image Selected'),
         )
-          : Container(
+          : SingleChildScrollView(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               RotatedBox(
                 quarterTurns: _direction,
                 child: Image.file(_image)
               ),
+              Flexible(
+                child:
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: <Widget>[
@@ -55,6 +58,7 @@ class ImageScreenState extends State<ImageScreen> {
                     icon: Icon(Icons.rotate_right),
                   ),
                 ],
+              )
               )
             ],
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_custom_tabs: ^0.4.0
   image_picker: ^0.4.10
   font_awesome_flutter: ^8.0.1
+  http: ^0.12.0+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes [this issue](url)

Observed another issue after fixing above. ie, `rotate` buttons were not displayed properly and hidden behind `bottomnavigationbar` and user was not able to tap on them or scroll the screen, as below:

![screen shot 2019-01-13 at 11 10 45 pm](https://user-images.githubusercontent.com/16548367/51196823-ef38de80-1915-11e9-968b-8e67e3efd69b.png)


Fixed above issue by replacing `Container` with `SingleChildScrollView` and added `mainAxisSize` as `min` so that user can scroll and tap on `rotate` button properly as shown in below gif:


https://media.giphy.com/media/9JcJYnE5fNzLE7b0SQ/giphy.gif

Feedback / suggestion welcome.

